### PR TITLE
Add adjacent day views

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -40,3 +40,26 @@
 .read-the-docs {
   color: #888;
 }
+
+.days {
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  margin-top: 1rem;
+}
+
+.day {
+  flex: 1;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.day.focus {
+  outline: 2px solid #646cff;
+}
+
+.tasks {
+  list-style: none;
+  padding-left: 0;
+}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,15 +13,27 @@ interface TaskDetail extends Task {
 function App() {
   const today = new Date().toISOString().substring(0,10);
   const [tasks, setTasks] = useState<Task[]>([]);
+  const [prevTasks, setPrevTasks] = useState<Task[]>([]);
+  const [nextTasks, setNextTasks] = useState<Task[]>([]);
   const [text, setText] = useState('');
   const [date, setDate] = useState(today);
   const [selected, setSelected] = useState<number | null>(null);
   const [details, setDetails] = useState<TaskDetail | null>(null);
 
-  const fetchTasks = async (d = date) => {
+  const fetchTasks = async (d: string) => {
     const res = await fetch(`/api/tasks?date=${d}`);
-    const data = await res.json();
-    setTasks(data);
+    return res.json();
+  };
+
+  const loadTasks = async (d = date) => {
+    const current = await fetchTasks(d);
+    setTasks(current);
+    const prev = new Date(d);
+    prev.setDate(prev.getDate() - 1);
+    setPrevTasks(await fetchTasks(prev.toISOString().substring(0, 10)));
+    const next = new Date(d);
+    next.setDate(next.getDate() + 1);
+    setNextTasks(await fetchTasks(next.toISOString().substring(0, 10)));
   };
 
   const fetchDetails = async (id: number) => {
@@ -30,7 +42,7 @@ function App() {
     setDetails(data);
   };
 
-  useEffect(() => { fetchTasks(); }, [date]);
+  useEffect(() => { loadTasks(); }, [date]);
 
   const addTask = async () => {
     if (!text) return;
@@ -40,13 +52,13 @@ function App() {
       body: JSON.stringify({ text, date })
     });
     setText('');
-    fetchTasks();
+    loadTasks();
   };
 
   const deleteTask = async (id: number) => {
     await fetch(`/api/tasks/${id}`, { method: 'DELETE' });
     if (selected === id) setSelected(null);
-    fetchTasks();
+    loadTasks();
   };
 
   const editTask = async (task: Task) => {
@@ -57,7 +69,7 @@ function App() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ text: newText })
     });
-    fetchTasks();
+    loadTasks();
   };
 
   const prevDay = () => {
@@ -69,6 +81,17 @@ function App() {
     const d = new Date(date);
     d.setDate(d.getDate() + 1);
     setDate(d.toISOString().substring(0,10));
+  };
+
+  const prevDateStr = () => {
+    const d = new Date(date);
+    d.setDate(d.getDate() - 1);
+    return d.toISOString().substring(0,10);
+  };
+  const nextDateStr = () => {
+    const d = new Date(date);
+    d.setDate(d.getDate() + 1);
+    return d.toISOString().substring(0,10);
   };
 
   const selectTask = (id: number) => {
@@ -89,29 +112,78 @@ function App() {
         <input type="date" value={date} onChange={e => setDate(e.target.value)} />
         <button onClick={nextDay}>Next</button>
       </div>
-      <div className="new-task">
-        <input value={text} onChange={e => setText(e.target.value)} placeholder="New task" />
-        <button onClick={addTask}>Add</button>
-      </div>
-      <ul className="tasks">
-        {tasks.map(t => (
-          <li key={t.id}>
-            <span onClick={() => selectTask(t.id)} className="task-text">{t.text}</span>
-            <button onClick={() => editTask(t)}>Edit</button>
-            <button onClick={() => deleteTask(t.id)}>Delete</button>
-            {selected === t.id && details && (
-              <div className="details">
-                <p>{details.notes}</p>
-                {details.subtasks.length > 0 && (
-                  <ul>
-                    {details.subtasks.map(s => <li key={s.id}>{s.text}</li>)}
-                  </ul>
+      <div className="days">
+        <div className="day">
+          <h3>{prevDateStr()}</h3>
+          <ul className="tasks">
+            {prevTasks.map(t => (
+              <li key={t.id}>
+                <span onClick={() => selectTask(t.id)} className="task-text">{t.text}</span>
+                <button onClick={() => editTask(t)}>Edit</button>
+                <button onClick={() => deleteTask(t.id)}>Delete</button>
+                {selected === t.id && details && (
+                  <div className="details">
+                    <p>{details.notes}</p>
+                    {details.subtasks.length > 0 && (
+                      <ul>
+                        {details.subtasks.map(s => <li key={s.id}>{s.text}</li>)}
+                      </ul>
+                    )}
+                  </div>
                 )}
-              </div>
-            )}
-          </li>
-        ))}
-      </ul>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="day focus">
+          <h3>{date}</h3>
+          <div className="new-task">
+            <input value={text} onChange={e => setText(e.target.value)} placeholder="New task" />
+            <button onClick={addTask}>Add</button>
+          </div>
+          <ul className="tasks">
+            {tasks.map(t => (
+              <li key={t.id}>
+                <span onClick={() => selectTask(t.id)} className="task-text">{t.text}</span>
+                <button onClick={() => editTask(t)}>Edit</button>
+                <button onClick={() => deleteTask(t.id)}>Delete</button>
+                {selected === t.id && details && (
+                  <div className="details">
+                    <p>{details.notes}</p>
+                    {details.subtasks.length > 0 && (
+                      <ul>
+                        {details.subtasks.map(s => <li key={s.id}>{s.text}</li>)}
+                      </ul>
+                    )}
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="day">
+          <h3>{nextDateStr()}</h3>
+          <ul className="tasks">
+            {nextTasks.map(t => (
+              <li key={t.id}>
+                <span onClick={() => selectTask(t.id)} className="task-text">{t.text}</span>
+                <button onClick={() => editTask(t)}>Edit</button>
+                <button onClick={() => deleteTask(t.id)}>Delete</button>
+                {selected === t.id && details && (
+                  <div className="details">
+                    <p>{details.notes}</p>
+                    {details.subtasks.length > 0 && (
+                      <ul>
+                        {details.subtasks.map(s => <li key={s.id}>{s.text}</li>)}
+                      </ul>
+                    )}
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show tasks for the previous and next day alongside the chosen date
- highlight the current day panel

## Testing
- `npm run build` in `client`
- `npm run build` in `server`


------
https://chatgpt.com/codex/tasks/task_e_6888866f56908331964d92705fa09973