### PR TITLE
Fix task copy functionality: use task date and prevent duplicates

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import './App.css';
 
 interface Task {
@@ -44,7 +44,7 @@ function App() {
     return date.toISOString().substring(0, 10);
   };
 
-  const fetchAllTasks = async (d = date) => {
+  const fetchAllTasks = useCallback(async (d = date) => {
     const prevDate = getPrevDate(d);
     const nextDate = getNextDate(d);
     
@@ -61,7 +61,7 @@ function App() {
     setPrevTasks(prevData);
     setCurrentTasks(currentData);
     setNextTasks(nextData);
-  };
+  }, [date]);
 
   const fetchDetails = async (id: number) => {
     const res = await fetch(`/api/tasks/${id}`);
@@ -131,7 +131,7 @@ function App() {
 
   const copyToNextDay = async (task: Task) => {
     try {
-      const nextDate = getNextDate(date);
+      const nextDate = getNextDate(task.date);
       console.log(`Copying task ${task.id} to ${nextDate}`);
       const response = await fetch(`/api/tasks/${task.id}/copy`, {
         method: 'POST',

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -119,6 +119,15 @@ app.post('/api/tasks/:id/copy', async (req, res) => {
       return res.status(404).json({ error: 'not found' });
     }
     
+    const existingCopy = await db.get(
+      'SELECT id FROM tasks WHERE task_group_id = ? AND date = ?', 
+      task.task_group_id, target_date
+    );
+    if (existingCopy) {
+      console.log(`Task already copied to ${target_date}`);
+      return res.status(409).json({ error: 'Task has already been copied to this date' });
+    }
+    
     console.log(`Copying task "${task.text}" to date: ${target_date}`);
     const result: any = await db.run('INSERT INTO tasks(text, notes, date, task_group_id) VALUES(?, ?, ?, ?)', 
       task.text, task.notes, target_date, task.task_group_id);


### PR DESCRIPTION
# Fix task copy functionality: use task date and prevent duplicates

## Summary

This PR addresses two issues with the task copying functionality:

1. **Date calculation fix**: When copying a task to the next day, the system now uses the task's own date to calculate the target date instead of using the currently selected date in the UI. This prevents counterintuitive behavior where copying a task from a previous day while viewing a different day would copy to the wrong date.

2. **Duplicate prevention**: Added server-side logic to prevent copying the same task to the same target date multiple times. The system now returns a 409 Conflict error when attempting to create a duplicate copy.

**Additional fix**: Resolved a React infinite loop issue in `fetchAllTasks` by wrapping it with `useCallback`.

## Review & Testing Checklist for Human

- [x] **Database schema compatibility**: Verify that production databases have the `task_group_id` column. During testing, I had to recreate the local database because it was missing this column.
- [x] **Date calculation edge cases**: Test copying tasks across month boundaries, year boundaries, and around leap years to ensure the date calculation works correctly in all scenarios.
- [x] **User experience for duplicates**: Test attempting to copy the same task multiple times and verify the user receives appropriate feedback (currently only logs to console).
- [x] **End-to-end copy functionality**: Create tasks on various dates, navigate to different days in the UI, and verify copies always go to the correct target date (task's date + 1 day).
- [x] **React dependency fix**: Verify that the `useCallback` fix for `fetchAllTasks` doesn't break other functionality like task creation, editing, or deletion.

**Recommended test plan**: Create tasks on different days, navigate around the UI, and test copying from various scenarios while monitoring both the UI behavior and server logs.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    Client["client/src/App.tsx"]:::major-edit --> CopyFunc["copyToNextDay()<br/>Uses task.date instead of selected date"]:::major-edit
    Client --> FetchFunc["fetchAllTasks()<br/>Added useCallback"]:::minor-edit
    
    CopyFunc --> CopyAPI["/api/tasks/:id/copy<br/>server/src/index.ts"]:::major-edit
    CopyAPI --> DupeCheck["Duplicate Prevention<br/>Check task_group_id + target_date"]:::major-edit
    CopyAPI --> Database[("SQLite Database<br/>tasks table")]:::context
    
    DupeCheck --> Success["201: Task copied successfully"]:::context
    DupeCheck --> Conflict["409: Already copied to this date"]:::context
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#FFFFFF
```

### Notes

- **Session URL**: https://app.devin.ai/sessions/0102051304b94d0db3ba3fe918818808
- **Requested by**: Sam Don (@sam-don)
- **Testing**: Verified locally with task creation, copying, and duplicate prevention scenarios
- **Lint status**: Both client and server lint checks passed successfully

The changes are focused and address the specific issues mentioned, but careful testing is recommended due to the database schema dependency and date calculation logic.